### PR TITLE
[DRAFT] feat: add docker_coder image and CI build job

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -116,6 +116,16 @@ jobs:
           source ./tool.sh
           build_image nocobase latest docker_nocobase/nocobase.Dockerfile && push_image nocobase
 
+  ## coder for remote development
+  job-coder:
+    name: 'coder'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: |
+          source ./tool.sh
+          build_image coder latest docker_coder/coder.Dockerfile && push_image coder
+
 
   ## DevBox - base
   job-base-dev:
@@ -178,7 +188,7 @@ jobs:
 
   ## Sync all images in this build (listed by "names") to mirror registry.
   sync_images:
-    needs: ["job-cuda-dev", "job-data-science-dev", "job-full-stack-dev", "job-base-dev", "job-nocobase", "job-logent", "job-storebox", "job-searxng", "job-openresty", "job-dev-hub", "docker_keycloak", "docker_casdoor", "docker_clash"]
+    needs: ["job-cuda-dev", "job-data-science-dev", "job-full-stack-dev", "job-base-dev", "job-nocobase", "job-logent", "job-storebox", "job-searxng", "job-openresty", "job-dev-hub", "job-coder", "docker_keycloak", "docker_casdoor", "docker_clash"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/docker_coder/coder.Dockerfile
+++ b/docker_coder/coder.Dockerfile
@@ -1,0 +1,16 @@
+# Distributed under the terms of the Modified BSD License.
+
+ARG BASE_NAMESPACE
+ARG BASE_IMG="base"
+
+FROM ${BASE_NAMESPACE:+$BASE_NAMESPACE/}${BASE_IMG}
+
+COPY work /opt/utils
+
+RUN set -eux \
+ # ----------------------------- Install terraform
+ && source /opt/utils/script-setup-coder.sh && setup_terraform \
+ # ----------------------------- Install coder
+ && source /opt/utils/script-setup-coder.sh && setup_coder \
+ # Clean up and display components version information...
+ && list_installed_packages && install__clean

--- a/docker_coder/work/script-setup-coder.sh
+++ b/docker_coder/work/script-setup-coder.sh
@@ -1,0 +1,39 @@
+source /opt/utils/script-utils.sh
+
+
+setup_terraform() {
+  ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') \
+  && [[ "$ARCH" =~ ^(amd64|arm64)$ ]] || {
+    echo "Unsupported architecture for terraform: $(uname -m)" && return 1 ;
+  }
+
+  VER_TERRAFORM=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/hashicorp/terraform/releases/latest | grep -oP 'v\K[\d.]+')
+  URL_TERRAFORM="https://releases.hashicorp.com/terraform/${VER_TERRAFORM}/terraform_${VER_TERRAFORM}_linux_${ARCH}.zip"
+
+  echo "Installing terraform v${VER_TERRAFORM} for arch ${ARCH} from: ${URL_TERRAFORM}" \
+  && curl -fSL -o /tmp/terraform.zip "${URL_TERRAFORM}" \
+  && unzip -oj /tmp/terraform.zip terraform -d /tmp/ \
+  && install -m 0755 -D /tmp/terraform /opt/bin/terraform \
+  && ln -sf /opt/bin/terraform /usr/bin/terraform \
+  && rm -f /tmp/terraform.zip /tmp/terraform \
+  && echo "@ Installed terraform: $(terraform version | head -1)"
+}
+
+
+setup_coder() {
+  ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') \
+  && [[ "$ARCH" =~ ^(amd64|arm64)$ ]] || {
+    echo "Unsupported architecture for coder: $(uname -m)" && return 1 ;
+  }
+
+  VER_CODER=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/coder/coder/releases/latest | grep -oP 'v\K[\d.]+')
+  URL_CODER="https://github.com/coder/coder/releases/download/v${VER_CODER}/coder_${VER_CODER}_linux_${ARCH}.tar.gz"
+
+  echo "Installing coder v${VER_CODER} for arch ${ARCH} from: ${URL_CODER}" \
+  && curl -fSL -o /tmp/coder.tar.gz "${URL_CODER}" \
+  && tar -xzf /tmp/coder.tar.gz -C /tmp \
+  && install -m 0755 -D /tmp/coder /opt/bin/coder \
+  && ln -sf /opt/bin/coder /usr/bin/coder \
+  && rm -f /tmp/coder.tar.gz /tmp/coder \
+  && echo "@ Installed coder: $(coder version)"
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated `coder` Docker image that bundles Terraform and Coder for remote development and integrate its build into the existing CI image pipeline.

### Description
- Add `docker_coder/coder.Dockerfile` based on the existing `base` image which sources install helpers and runs `setup_terraform` and `setup_coder` during image build.
- Add `docker_coder/work/script-setup-coder.sh` implementing `setup_terraform` and `setup_coder` bash functions with architecture detection, downstream release download, install to `/opt/bin`, symlinks to `/usr/bin`, and version output, following style of other `docker_*` scripts.
- Update `.github/workflows/build-docker.yml` to add a `job-coder` job that builds and pushes the `coder` image and include `job-coder` in the `sync_images.needs` list so it participates in the image sync step.
- Created branch `dev/add-coder` and opened this change as a draft PR for review of image contents and CI addition.

### Testing
- Ran `bash -n docker_coder/work/script-setup-coder.sh` to validate the new script's shell syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f89d773c8320b06daac42c5041e6)