### PR TITLE
docker_coder: preinstall Terraform providers via local mirror

### DIFF
--- a/docker_coder/coder.Dockerfile
+++ b/docker_coder/coder.Dockerfile
@@ -10,6 +10,7 @@ COPY work /opt/utils
 RUN set -eux \
  # ----------------------------- Install terraform
  && source /opt/utils/script-setup-coder.sh && setup_terraform \
+ && source /opt/utils/script-setup-coder.sh && setup_terraform_providers \
  # ----------------------------- Install coder
  && source /opt/utils/script-setup-coder.sh && setup_coder \
  # Clean up and display components version information...

--- a/docker_coder/work/script-setup-coder.sh
+++ b/docker_coder/work/script-setup-coder.sh
@@ -20,6 +20,64 @@ setup_terraform() {
 }
 
 
+setup_terraform_providers() {
+  local mirror_dir="/opt/terraform-providers"
+  local plugin_cache_dir="/opt/terraform-plugin-cache"
+  local bootstrap_dir="/tmp/terraform-provider-bootstrap"
+
+  mkdir -p "${mirror_dir}" "${plugin_cache_dir}" "${bootstrap_dir}" /etc/terraform.d
+
+  cat >"${bootstrap_dir}/main.tf" <<'EOF'
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.5.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = ">= 3.0.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0.0"
+    }
+  }
+}
+EOF
+
+  echo "Installing terraform providers to mirror: ${mirror_dir}" \
+  && terraform -chdir="${bootstrap_dir}" init -backend=false \
+  && terraform -chdir="${bootstrap_dir}" providers mirror "${mirror_dir}" \
+  && cat >/etc/terraform.d/terraform.rc <<EOF
+plugin_cache_dir = "${plugin_cache_dir}"
+
+provider_installation {
+  filesystem_mirror {
+    path    = "${mirror_dir}"
+    include = [
+      "coder/coder",
+      "hashicorp/http",
+      "kreuzwerker/docker",
+    ]
+  }
+
+  direct {
+    exclude = [
+      "coder/coder",
+      "hashicorp/http",
+      "kreuzwerker/docker",
+    ]
+  }
+}
+EOF
+
+  ln -sf /etc/terraform.d/terraform.rc /root/.terraformrc \
+  && rm -rf "${bootstrap_dir}" \
+  && echo "@ Installed terraform providers mirror at ${mirror_dir}"
+}
+
+
 setup_coder() {
   ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') \
   && [[ "$ARCH" =~ ^(amd64|arm64)$ ]] || {


### PR DESCRIPTION
### Motivation

- Terraform provider downloads fail in restricted/networked environments when attempting to pull from remote registries, causing image build or runtime failures.

### Description

- Add `setup_terraform_providers` to `docker_coder/work/script-setup-coder.sh` to bootstrap a minimal `main.tf`, run `terraform init` and `terraform providers mirror` to mirror required providers into `/opt/terraform-providers`.
- Generate `/etc/terraform.d/terraform.rc` (and symlink `/root/.terraformrc`) to configure Terraform to prefer the local filesystem mirror and set a plugin cache directory at `/opt/terraform-plugin-cache`.
- Invoke `setup_terraform_providers` from `docker_coder/coder.Dockerfile` immediately after `setup_terraform` to bake providers into the image at build time.

### Testing

- Run a shell syntax check with `bash -n docker_coder/work/script-setup-coder.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8068b85108320b9a07382aa9d61e2)